### PR TITLE
fix: matching miktex repository with ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN    apt-get update \
            perl
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D6BC243565B2087BC3F897C9277A7293F59E4889
-RUN echo "deb http://miktex.org/download/ubuntu focal universe" | tee /etc/apt/sources.list.d/miktex.list
+RUN echo "deb http://miktex.org/download/ubuntu bionic universe" | tee /etc/apt/sources.list.d/miktex.list
 
 RUN    apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Hi @edocevoli, this simple line of miktex repository matching with ubuntu bionic fixes the #26 issue, which we've reproduced many times. Thanks. 