### PR TITLE
Override language.dat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ RUN    miktexsetup finish \
     && mpm --admin --update-db \
     && mpm --admin \
            --install amsfonts \
-           --install biber-linux-x86_64 \
-    && initexmf --admin --update-fndb
+           --install biber-linux-x86_64
+
+COPY language.dat /var/lib/miktex-texmf/tex/generic/config/language.dat
+RUN initexmf --admin --update-fndb
 
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/language.dat
+++ b/language.dat
@@ -1,0 +1,93 @@
+english hyphen.tex
+=usenglish
+=USenglish
+=american
+afrikaans loadhyph-af.tex
+ancientgreek loadhyph-grc.tex
+armenian loadhyph-hy.tex
+assamese loadhyph-as.tex
+basque loadhyph-eu.tex
+belarusian loadhyph-be.tex
+bengali loadhyph-bn.tex
+bokmal loadhyph-nb.tex
+=norwegian
+=norsk
+bulgarian loadhyph-bg.tex
+catalan loadhyph-ca.tex
+churchslavonic loadhyph-cu.tex
+classiclatin loadhyph-la-x-classic.tex
+coptic loadhyph-cop.tex
+croatian loadhyph-hr.tex
+czech loadhyph-cs.tex
+danish loadhyph-da.tex
+dutch loadhyph-nl.tex
+esperanto loadhyph-eo.tex
+estonian loadhyph-et.tex
+ethiopic loadhyph-mul-ethi.tex
+=amharic
+=geez
+finnish loadhyph-fi.tex
+french loadhyph-fr.tex
+=patois
+=francais
+friulan loadhyph-fur.tex
+galician loadhyph-gl.tex
+georgian loadhyph-ka.tex
+german loadhyph-de-1901.tex
+greek loadhyph-el-polyton.tex
+=polygreek
+gujarati loadhyph-gu.tex
+hindi loadhyph-hi.tex
+hungarian loadhyph-hu.tex
+icelandic loadhyph-is.tex
+indonesian loadhyph-id.tex
+interlingua loadhyph-ia.tex
+irish loadhyph-ga.tex
+italian loadhyph-it.tex
+kannada loadhyph-kn.tex
+kurmanji loadhyph-kmr.tex
+latin loadhyph-la.tex
+latvian loadhyph-lv.tex
+lithuanian loadhyph-lt.tex
+liturgicallatin loadhyph-la-x-liturgic.tex
+macedonian loadhyph-mk.tex
+malayalam loadhyph-ml.tex
+marathi loadhyph-mr.tex
+mongolian loadhyph-mn-cyrl.tex
+mongolianlmc loadhyph-mn-cyrl-x-lmc.tex
+monogreek loadhyph-el-monoton.tex
+ngerman loadhyph-de-1996.tex
+nynorsk loadhyph-nn.tex
+occitan loadhyph-oc.tex
+oriya loadhyph-or.tex
+pali loadhyph-pi.tex
+panjabi loadhyph-pa.tex
+piedmontese loadhyph-pms.tex
+polish loadhyph-pl.tex
+portuguese loadhyph-pt.tex
+=portuges
+romanian loadhyph-ro.tex
+romansh loadhyph-rm.tex
+russian loadhyph-ru.tex
+sanskrit loadhyph-sa.tex
+serbian loadhyph-sr-latn.tex
+serbianc loadhyph-sr-cyrl.tex
+slovak loadhyph-sk.tex
+slovenian loadhyph-sl.tex
+=slovene
+spanish loadhyph-es.tex
+=espanol
+swedish loadhyph-sv.tex
+swissgerman loadhyph-de-ch-1901.tex
+tamil loadhyph-ta.tex
+telugu loadhyph-te.tex
+thai loadhyph-th.tex
+turkish loadhyph-tr.tex
+turkmen loadhyph-tk.tex
+ukenglish loadhyph-en-gb.tex
+=british
+=UKenglish
+ukrainian loadhyph-uk.tex
+uppersorbian loadhyph-hsb.tex
+usenglishmax loadhyph-en-us.tex
+welsh loadhyph-cy.tex


### PR DESCRIPTION
Maybe I did miss something, but without enabling other languages you can't use babel/hyphenation for other languages than English which results into https://github.com/MiKTeX/miktex/issues/1100