### PR TITLE
Change user id when $MIKTEX_UID is set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 MIKTEX_UID=${MIKTEX_UID:-1000}
 MIKTEX_GID=${MIKTEX_GID:-${MIKTEX_UID}}
-if [ "$(id -u miktex)" != 1000 ]; then
+if [ "$MIKTEX_UID" != 1000 ]; then
     usermod -u ${MIKTEX_UID} miktex >/dev/null
     groupmod -g ${MIKTEX_GID} miktex
     chown -R miktex:miktex /var/lib/miktex


### PR DESCRIPTION
If I understand the intention of $MIKTEX_UID correctly I think entrypoint.sh has a bug.

I have changed it to modify the user id if  $MIKTEX_UID != 1000.

And thanks for providing this container - it's fantastic to have a portable miktex setup :)