### PR TITLE
Quote the pwd in the docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provided that your main input file is located in the current working directory,
 you can run `pdflatex` as follows:
 
 ```sh
-docker run -ti -v miktex:/var/lib/miktex -v `pwd`:/miktex/work -e MIKTEX_UID=`id -u` miktex/miktex:essential \
+docker run -ti -v miktex:/var/lib/miktex -v "$(pwd):/miktex/work" -e MIKTEX_UID=$(id -u) miktex/miktex:essential \
     pdflatex main.tex
 ```
 


### PR DESCRIPTION
Modify the docker example to quote the current working directory.
This makes it more flexible, for example where there might be spaces in that folder name.